### PR TITLE
Fix wording: "Account" needs to be "Organization"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ The definition of this Github Action is in [action.yml](https://github.com/Azure
 
 ## Sample workflow 
 
-Use this action to trigger a specific pipeline (YAML or Classic Release Pipeline) in Azure DevOps account.
-Action takes Project URl, pipeline name and a [Personal Access Token (PAT)](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops) for your DevOps account.
+Use this action to trigger a specific pipeline (YAML or Classic Release Pipeline) in an Azure DevOps organization.
+Action takes Project URL, pipeline name and a [Personal Access Token (PAT)](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops) for your DevOps account.
 
 ```yaml
 - uses: Azure/pipelines@v1


### PR DESCRIPTION
- Changed "account" to "organization" to reflect the correct terms from Azure DevOps.
- Fixed casing to be all uppercase ("URl" --> "URL").