### PR TITLE
Add possibility to specify additional build parameters

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,11 @@ inputs:
     required: true 
   azure-devops-token: 
     description: 'Paste personal access token of the user as value of secret variable:AZURE_DEVOPS_TOKEN' 
-    required: true 
+    required: true
+  azure-pipeline-build-parameters:
+    description: 'Additional build parameters (serialized JSON to string)'
+    required: false
+    default: '{}'
 runs: 
   using: 'node12' 
   main: 'lib/main.js' 

--- a/lib/.gitattribute
+++ b/lib/.gitattribute
@@ -1,0 +1,1 @@
+* text=auto eol=crlf

--- a/lib/pipeline.runner.js
+++ b/lib/pipeline.runner.js
@@ -45,7 +45,7 @@ class PipelineRunner {
                 let pipelineName = this.taskParameters.azurePipelineName;
                 try {
                     core.debug(`Triggering Yaml pipeline : "${pipelineName}"`);
-                    yield this.RunYamlPipeline(webApi);
+                    yield this.RunYamlPipeline(webApi, taskParams.buildParameters);
                 }
                 catch (error) {
                     if (error instanceof pipeline_error_1.PipelineNotFoundError) {
@@ -63,7 +63,7 @@ class PipelineRunner {
             }
         });
     }
-    RunYamlPipeline(webApi) {
+    RunYamlPipeline(webApi, buildParameters) {
         return __awaiter(this, void 0, void 0, function* () {
             let projectName = url_parser_1.UrlParser.GetProjectName(this.taskParameters.azureDevopsProjectUrl);
             let pipelineName = this.taskParameters.azurePipelineName;
@@ -100,7 +100,8 @@ class PipelineRunner {
                 },
                 sourceBranch: sourceBranch,
                 sourceVersion: sourceVersion,
-                reason: BuildInterfaces.BuildReason.Triggered
+                reason: BuildInterfaces.BuildReason.Triggered,
+                parameters: buildParameters,
             };
             logger_1.Logger.LogPipelineTriggerInput(build);
             // Queue build

--- a/lib/task.parameters.js
+++ b/lib/task.parameters.js
@@ -13,6 +13,7 @@ class TaskParameters {
         this._azureDevopsProjectUrl = core.getInput('azure-devops-project-url', { required: true });
         this._azurePipelineName = core.getInput('azure-pipeline-name', { required: true });
         this._azureDevopsToken = core.getInput('azure-devops-token', { required: true });
+        this._buildParameters = core.getInput('azure-pipeline-build-parameters', { required: false });
     }
     static getTaskParams() {
         if (!this.taskparams) {
@@ -28,6 +29,9 @@ class TaskParameters {
     }
     get azureDevopsToken() {
         return this._azureDevopsToken;
+    }
+    get buildParameters() {
+        return this._buildParameters;
     }
 }
 exports.TaskParameters = TaskParameters;

--- a/src/pipeline.runner.ts
+++ b/src/pipeline.runner.ts
@@ -32,7 +32,7 @@ export class PipelineRunner {
             let pipelineName = this.taskParameters.azurePipelineName;
             try {
                 core.debug(`Triggering Yaml pipeline : "${pipelineName}"`);
-                await this.RunYamlPipeline(webApi);
+                await this.RunYamlPipeline(webApi, taskParams.buildParameters);
             }
             catch (error) {
                 if (error instanceof PipelineNotFoundError) {
@@ -48,7 +48,7 @@ export class PipelineRunner {
         }
     }
 
-    public async RunYamlPipeline(webApi: azdev.WebApi): Promise<any> {
+    public async RunYamlPipeline(webApi: azdev.WebApi, buildParameters: string): Promise<any> {
         let projectName = UrlParser.GetProjectName(this.taskParameters.azureDevopsProjectUrl);
         let pipelineName = this.taskParameters.azurePipelineName;
         let buildApi = await webApi.getBuildApi();
@@ -91,7 +91,8 @@ export class PipelineRunner {
             },
             sourceBranch: sourceBranch,
             sourceVersion: sourceVersion,
-            reason: BuildInterfaces.BuildReason.Triggered
+            reason: BuildInterfaces.BuildReason.Triggered,
+            parameters: buildParameters,
         } as BuildInterfaces.Build;
 
         log.LogPipelineTriggerInput(build);

--- a/src/task.parameters.ts
+++ b/src/task.parameters.ts
@@ -5,11 +5,13 @@ export class TaskParameters {
     private _azureDevopsProjectUrl: string;
     private _azurePipelineName: string;
     private _azureDevopsToken: string;
+    private _buildParameters: string;
 
     private constructor() {
         this._azureDevopsProjectUrl = core.getInput('azure-devops-project-url', { required: true });
         this._azurePipelineName = core.getInput('azure-pipeline-name', { required: true });
         this._azureDevopsToken = core.getInput('azure-devops-token', { required: true });
+        this._buildParameters = core.getInput('azure-pipeline-build-parameters', { required: false });
     }
 
     public static getTaskParams() {
@@ -30,5 +32,9 @@ export class TaskParameters {
 
     public get azureDevopsToken() {
         return this._azureDevopsToken;
+    }
+
+    public get buildParameters() {
+        return this._buildParameters;
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
       // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
       // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
       // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+      "newLine": "crlf",
   
       /* Strict Type-Checking Options */
       "strict": false,                           /* Enable all strict type-checking options. */


### PR DESCRIPTION
This PR allows specifying additional build parameters:

Input:
```js
{
  "definition": {
    "id": 28
  },
  "project": {
    "id": "..."
  },
  "sourceBranch": "refs/heads/master",
  "sourceVersion": "...",
  "reason": 943,
  "parameters": "{\"WORLD\": \"hello\"}"
}
```

In Azure Pipelines:
`bash: env | WORLD` -> `WORLD=hello`