### PR TITLE
Filter build definitions and only match exact pipeline names

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -178,7 +178,8 @@ describe('Testing all functions of class PipelineRunner', () => {
         jest.spyOn(core, 'debug').mockImplementation();
         jest.spyOn(core, 'info').mockImplementation();
         mockBuildDefinitions = [{
-            id: 5
+            id: 5,
+            name: 'my-pipeline'
         }];
         mockBuildDefinition = {
             id: 5,
@@ -231,7 +232,8 @@ describe('Testing all functions of class PipelineRunner', () => {
         jest.spyOn(core, 'info').mockImplementation();
         jest.spyOn(core, 'setFailed').mockImplementation();
         mockBuildDefinitions = [{
-            id: 5
+            id: 5,
+            name: 'my-pipeline'
         }];
         mockBuildDefinition = {
             id: 5,
@@ -304,7 +306,8 @@ describe('Testing all functions of class PipelineRunner', () => {
         mockBuildDefinitions = null;
         mockReleaseDefinitions = [{
             id: 5,
-            artifacts: []
+            artifacts: [],
+            name: 'my-pipeline'
         }];
         mockReleaseResponse = {
             _links: {

--- a/lib/pipeline.runner.js
+++ b/lib/pipeline.runner.js
@@ -69,7 +69,8 @@ class PipelineRunner {
             let pipelineName = this.taskParameters.azurePipelineName;
             let buildApi = yield webApi.getBuildApi();
             // Get matching build definitions for the given project and pipeline name
-            const buildDefinitions = yield buildApi.getDefinitions(projectName, pipelineName);
+            const buildDefinitions = (yield buildApi.getDefinitions(projectName, pipelineName))
+                .filter(buildDefinition => buildDefinition.name === pipelineName);
             pipeline_helper_1.PipelineHelper.EnsureValidPipeline(projectName, pipelineName, buildDefinitions);
             // Extract Id from build definition
             let buildDefinitionReference = buildDefinitions[0];
@@ -127,7 +128,8 @@ class PipelineRunner {
             let pipelineName = this.taskParameters.azurePipelineName;
             let releaseApi = yield webApi.getReleaseApi();
             // Get release definitions for the given project name and pipeline name
-            const releaseDefinitions = yield releaseApi.getReleaseDefinitions(projectName, pipelineName, ReleaseInterfaces.ReleaseDefinitionExpands.Artifacts);
+            const releaseDefinitions = (yield releaseApi.getReleaseDefinitions(projectName, pipelineName, ReleaseInterfaces.ReleaseDefinitionExpands.Artifacts))
+                .filter(releaseDefinition => releaseDefinition.name === pipelineName);
             pipeline_helper_1.PipelineHelper.EnsureValidPipeline(projectName, pipelineName, releaseDefinitions);
             let releaseDefinition = releaseDefinitions[0];
             logger_1.Logger.LogPipelineObject(releaseDefinition);

--- a/lib/pipeline.runner.js
+++ b/lib/pipeline.runner.js
@@ -64,13 +64,13 @@ class PipelineRunner {
         });
     }
     RunYamlPipeline(webApi) {
+        var _a;
         return __awaiter(this, void 0, void 0, function* () {
             let projectName = url_parser_1.UrlParser.GetProjectName(this.taskParameters.azureDevopsProjectUrl);
             let pipelineName = this.taskParameters.azurePipelineName;
             let buildApi = yield webApi.getBuildApi();
             // Get matching build definitions for the given project and pipeline name
-            const buildDefinitions = (yield buildApi.getDefinitions(projectName, pipelineName))
-                .filter(buildDefinition => buildDefinition.name === pipelineName);
+            const buildDefinitions = (_a = (yield buildApi.getDefinitions(projectName, pipelineName))) === null || _a === void 0 ? void 0 : _a.filter(buildDefinition => buildDefinition.name === pipelineName);
             pipeline_helper_1.PipelineHelper.EnsureValidPipeline(projectName, pipelineName, buildDefinitions);
             // Extract Id from build definition
             let buildDefinitionReference = buildDefinitions[0];
@@ -123,13 +123,13 @@ class PipelineRunner {
         });
     }
     RunDesignerPipeline(webApi) {
+        var _a;
         return __awaiter(this, void 0, void 0, function* () {
             let projectName = url_parser_1.UrlParser.GetProjectName(this.taskParameters.azureDevopsProjectUrl);
             let pipelineName = this.taskParameters.azurePipelineName;
             let releaseApi = yield webApi.getReleaseApi();
             // Get release definitions for the given project name and pipeline name
-            const releaseDefinitions = (yield releaseApi.getReleaseDefinitions(projectName, pipelineName, ReleaseInterfaces.ReleaseDefinitionExpands.Artifacts))
-                .filter(releaseDefinition => releaseDefinition.name === pipelineName);
+            const releaseDefinitions = (_a = (yield releaseApi.getReleaseDefinitions(projectName, pipelineName, ReleaseInterfaces.ReleaseDefinitionExpands.Artifacts))) === null || _a === void 0 ? void 0 : _a.filter(releaseDefinition => releaseDefinition.name === pipelineName);
             pipeline_helper_1.PipelineHelper.EnsureValidPipeline(projectName, pipelineName, releaseDefinitions);
             let releaseDefinition = releaseDefinitions[0];
             logger_1.Logger.LogPipelineObject(releaseDefinition);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5841,9 +5841,9 @@
       }
     },
     "typescript": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
-      "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.7.tgz",
+      "integrity": "sha512-MmQdgo/XenfZPvVLtKZOq9jQQvzaUAUpcKW8Z43x9B2fOm4S5g//tPtMweZUIP+SoBqrVPEIm+dJeQ9dfO0QdA==",
       "dev": true
     },
     "underscore": {

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
     "@types/q": "^1.5.2"
   },
   "devDependencies": {
+    "@types/jest": "^25.2.2",
     "@types/node": "^12.12.6",
-    "typescript": "^3.5.2",
     "azure-devops-node-api": "^9.0.1",
     "jest": "^26.0.1",
-    "@types/jest": "^25.2.2",
-    "ts-jest": "^25.5.1"
+    "ts-jest": "^25.5.1",
+    "typescript": "^3.7.7"
   },
   "scripts": {
     "build": "tsc",

--- a/src/pipeline.runner.ts
+++ b/src/pipeline.runner.ts
@@ -54,8 +54,7 @@ export class PipelineRunner {
         let buildApi = await webApi.getBuildApi();
 
         // Get matching build definitions for the given project and pipeline name
-        const buildDefinitions = (await buildApi.getDefinitions(projectName, pipelineName))
-          .filter(buildDefinition => buildDefinition.name === pipelineName);
+        const buildDefinitions = (await buildApi.getDefinitions(projectName, pipelineName))?.filter(buildDefinition => buildDefinition.name === pipelineName);
 
         p.EnsureValidPipeline(projectName, pipelineName, buildDefinitions);
 
@@ -121,8 +120,7 @@ export class PipelineRunner {
         let releaseApi = await webApi.getReleaseApi();
         // Get release definitions for the given project name and pipeline name
         const releaseDefinitions: ReleaseInterfaces.ReleaseDefinition[] =
-          (await releaseApi.getReleaseDefinitions(projectName, pipelineName, ReleaseInterfaces.ReleaseDefinitionExpands.Artifacts))
-            .filter(releaseDefinition => releaseDefinition.name === pipelineName);
+          (await releaseApi.getReleaseDefinitions(projectName, pipelineName, ReleaseInterfaces.ReleaseDefinitionExpands.Artifacts))?.filter(releaseDefinition => releaseDefinition.name === pipelineName);
 
         p.EnsureValidPipeline(projectName, pipelineName, releaseDefinitions);
 

--- a/src/pipeline.runner.ts
+++ b/src/pipeline.runner.ts
@@ -54,7 +54,8 @@ export class PipelineRunner {
         let buildApi = await webApi.getBuildApi();
 
         // Get matching build definitions for the given project and pipeline name
-        const buildDefinitions = await buildApi.getDefinitions(projectName, pipelineName);
+        const buildDefinitions = (await buildApi.getDefinitions(projectName, pipelineName))
+          .filter(buildDefinition => buildDefinition.name === pipelineName);
 
         p.EnsureValidPipeline(projectName, pipelineName, buildDefinitions);
 
@@ -119,7 +120,9 @@ export class PipelineRunner {
         let pipelineName = this.taskParameters.azurePipelineName;
         let releaseApi = await webApi.getReleaseApi();
         // Get release definitions for the given project name and pipeline name
-        const releaseDefinitions: ReleaseInterfaces.ReleaseDefinition[] = await releaseApi.getReleaseDefinitions(projectName, pipelineName, ReleaseInterfaces.ReleaseDefinitionExpands.Artifacts);
+        const releaseDefinitions: ReleaseInterfaces.ReleaseDefinition[] =
+          (await releaseApi.getReleaseDefinitions(projectName, pipelineName, ReleaseInterfaces.ReleaseDefinitionExpands.Artifacts))
+            .filter(releaseDefinition => releaseDefinition.name === pipelineName);
 
         p.EnsureValidPipeline(projectName, pipelineName, releaseDefinitions);
 


### PR DESCRIPTION
Fixes #33

tl;dr - current pipeline search returns all matches with names _containing_ the supplied pipeline name. This fix is to filter the results to only matches that _exactly_ match the supplied pipeline name.

Also: update typescript to 3.7+ to support null coalescence operator